### PR TITLE
fix: preserve data for special tiles

### DIFF
--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -53,7 +53,10 @@ function fromSpecialTile(specialTile: SpecialTile): Tile {
 }
 export function addSpecialTiles(tiles: Record<string, Tile>) {
   for (const specialTile of Object.values(specialTiles)) {
-    tiles[specialTile.id] = fromSpecialTile(specialTile)
+    tiles[specialTile.id] = {
+      ...tiles[specialTile.id],
+      ...fromSpecialTile(specialTile)
+    }
   }
   return tiles
 }

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -53,10 +53,9 @@ function fromSpecialTile(specialTile: SpecialTile): Tile {
 }
 export function addSpecialTiles(tiles: Record<string, Tile>) {
   for (const specialTile of Object.values(specialTiles)) {
-    tiles[specialTile.id] = {
-      ...tiles[specialTile.id],
-      ...fromSpecialTile(specialTile)
-    }
+    tiles[specialTile.id] = specialTile.id in tiles
+        ? tiles[specialTile.id]
+        : fromSpecialTile(specialTile)
   }
   return tiles
 }


### PR DESCRIPTION
We are missing information for tiles listed in `/src/modules/map/data/specialTiles.json`

<img width="903" alt="Screen Shot 2021-02-02 at 12 37 18" src="https://user-images.githubusercontent.com/208789/106623473-666c5a00-6553-11eb-9c59-00adb5ed4684.png">

This change merge data get from the node with data from `specialTiles.json`