### PR TITLE
fix: fail when server is not ready

### DIFF
--- a/src/adapters/routes.ts
+++ b/src/adapters/routes.ts
@@ -7,6 +7,7 @@ import {
   createParcelMapPngRequestHandler,
   createParcelRequestHandler,
   createPingRequestHandler,
+  createReadyRequestHandler,
   createTilesRequestHandler,
   createTokenRequestHandler,
 } from './handlers'
@@ -15,7 +16,7 @@ import { register, Counter } from 'prom-client'
 
 const districtByIdCounter = new Counter({
   name: 'dcl_districts_by_id_counter',
-  help: 'How many times the districtbyid was called'
+  help: 'How many times the districtbyid was called',
 })
 
 export function setupRoutes(
@@ -37,6 +38,7 @@ export function setupRoutes(
     createEstateMapPngRequestHandler(components)
   )
   server.get('/v2/ping', createPingRequestHandler(components))
+  server.get('/v2/ready', createReadyRequestHandler(components))
   server.get('/v2/parcels/:x/:y', createParcelRequestHandler(components))
   server.get('/v2/estates/:id', createEstateRequestHandler(components))
   server.get(
@@ -65,11 +67,8 @@ export function setupRoutes(
       body: district.getContributionsByAddress(req.params.address),
     }))
   )
-  server.get(
-    '/metrics',
-    async (req, res) => {
-      res.header("content-type", register.contentType)
-      res.send(await register.metrics())
-    }
-  )
+  server.get('/metrics', async (req, res) => {
+    res.header('content-type', register.contentType)
+    res.send(await register.metrics())
+  })
 }

--- a/src/modules/map/component.ts
+++ b/src/modules/map/component.ts
@@ -25,6 +25,7 @@ export function createMapComponent(components: {
   let estates = future<Record<string, NFT>>()
   let tokens = future<Record<string, NFT>>()
   let inited = false
+  let ready = false
   let lastUpdatedAt = 0
 
   // sort
@@ -93,6 +94,7 @@ export function createMapComponent(components: {
           parcels.resolve(addParcels(result.parcels, {}))
           estates.resolve(addEstates(result.estates, {}))
           tokens.resolve(addTokens(result.parcels, result.estates, {}))
+          ready = true
           setTimeout(poll, refreshInterval)
           events.emit(MapEvents.READY, result)
         })
@@ -172,6 +174,10 @@ export function createMapComponent(components: {
     return result || null
   }
 
+  function isReady() {
+    return ready
+  }
+
   function getLastUpdatedAt() {
     return lastUpdatedAt
   }
@@ -183,6 +189,7 @@ export function createMapComponent(components: {
     getParcel,
     getEstate,
     getToken,
+    isReady,
     getLastUpdatedAt,
   }
 }

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -21,6 +21,7 @@ export interface IMapComponent {
   getParcel: (x: string | number, y: string | number) => Promise<NFT | null>
   getEstate: (id: string) => Promise<NFT | null>
   getToken: (contractAddress: string, tokenId: string) => Promise<NFT | null>
+  isReady: () => boolean
   getLastUpdatedAt: () => number
 }
 

--- a/src/modules/server/component.ts
+++ b/src/modules/server/component.ts
@@ -45,7 +45,7 @@ export function createServerComponent(components: {
 
   function failure(res: Response) {
     return (error: Error) => {
-      res.status(500).send({ ok: false, error })
+      res.status(500).send({ ok: false, error: error.message })
       events.emit(ServerEvents.ERROR, error)
     }
   }


### PR DESCRIPTION
To prevent enqueuing too many request that end up killing the server

also added a `/ready` endpoint that hopefully we could use some day to prevent exposing the server until it's ready