### PR TITLE
Feat: logging

### DIFF
--- a/src/controllers/handlers.ts
+++ b/src/controllers/handlers.ts
@@ -13,9 +13,14 @@ export const createTilesRequestHandler = (
         return { status: 503, body: 'Not ready' }
       }
       const tiles = await map.getTiles()
+      const data = getFilterFromUrl(context.url, tiles)
+
       return {
         status: 200,
-        body: { ok: true, data: getFilterFromUrl(context.url, tiles) },
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ ok: true, data }),
       }
     },
     [map.getLastUpdatedAt]
@@ -32,9 +37,14 @@ export const createLegacyTilesRequestHandler = (
         return { status: 503, body: 'Not ready' }
       }
       const tiles = await map.getTiles()
+      const data = toLegacyTiles(getFilterFromUrl(context.url, tiles))
+
       return {
         status: 200,
-        body: { ok: true, data: toLegacyTiles(getFilterFromUrl(context.url, tiles)) },
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ ok: true, data })
       }
     },
     [map.getLastUpdatedAt]

--- a/src/modules/api/component.ts
+++ b/src/modules/api/component.ts
@@ -226,6 +226,15 @@ export async function createApiComponent(components: {
       }`
       )
 
+      if (!parcels.length && !estates.length) {
+        return {
+          tiles: [],
+          parcels: [],
+          estates: [],
+          updatedAt: updatedAfter
+        }
+      }
+
       const updatedTiles = parcels.map(buildTile)
       const updatedParcels = parcels.map(buildParcel)
       const updatedEstates = parcels

--- a/src/modules/api/utils.ts
+++ b/src/modules/api/utils.ts
@@ -11,13 +11,19 @@ import { sleep } from '../map/utils'
 // helper to do GraphQL queries with retry logic
 export async function graphql<T>(url: string, query: string, retries = 5, retryDelay = 500): Promise<T> {
   try {
-    const result: { data: T } = await fetch(url, {
+    const res = await fetch(url, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query,
       }),
-    }).then((resp) => resp.json())
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch TheGraph: ${await res.text()}`)
+    }
+
+    const result: { data: T } = await res.json()
 
     if (!result || !result.data || Object.keys(result.data).length === 0) {
       throw new Error(`Invalid response. Result: ${JSON.stringify(result)}`)

--- a/src/modules/api/utils.ts
+++ b/src/modules/api/utils.ts
@@ -20,7 +20,7 @@ export async function graphql<T>(url: string, query: string, retries = 5, retryD
     }).then((resp) => resp.json())
 
     if (!result || !result.data || Object.keys(result.data).length === 0) {
-      throw new Error('Invalid response')
+      throw new Error(`Invalid response. Result: ${JSON.stringify(result)}`)
     }
 
     return result.data


### PR DESCRIPTION
Stringify the body cached to prevent _strigifying_ on each cached response  for `[v1 | v2]/tiles/`
```
# No stringify
Percentage of the requests served within a certain time (ms)
  50%  39029
  66%  44888
  75%  48383
  80%  51718
  90%  58588
  95%  65230
  98%  75542
  99%  75557
 100%  83854 (longest request)

# Stringify only data
Percentage of the requests served within a certain time (ms)
  50%  32793
  66%  35273
  75%  37128
  80%  37561
  90%  42738
  95%  44463
  98%  51569
  99%  51641
 100%  68894 (longest request)

# Stringify body
Percentage of the requests served within a certain time (ms)
  50%  13339
  66%  14510
  75%  15362
  80%  15938
  90%  17276
  95%  18657
  98%  20694
  99%  21507
 100%  23894 (longest request)
 ```