### PR TITLE
feat: respond a valid NFT for dissolved estates

### DIFF
--- a/src/controllers/handlers.ts
+++ b/src/controllers/handlers.ts
@@ -221,7 +221,12 @@ export const estateRequestHandler = async (context: {
   if (estate) {
     return { status: 200, body: estate }
   } else {
-    return { status: 404, body: { ok: false, error: 'Not Found' } }
+    const dissolvedEstate = await map.getDissolvedEstate(id)
+    if (dissolvedEstate) {
+      return { status: 200, body: dissolvedEstate }
+    } else {
+      return { status: 404, body: { ok: false, error: 'Not Found' } }
+    }
   }
 }
 
@@ -250,6 +255,16 @@ export const tokenRequestHandler = async (context: {
 
     return { status: 200, headers, body: token }
   } else {
+    const estateContractAddress = await config.requireString(
+      'ESTATE_CONTRACT_ADDRESS'
+    )
+
+    if (address === estateContractAddress) {
+      const dissolvedEstate = await map.getDissolvedEstate(id)
+      if (dissolvedEstate) {
+        return { status: 200, body: dissolvedEstate }
+      }
+    }
     return { status: 404, body: { ok: false, error: 'Not Found' } }
   }
 }

--- a/src/modules/api/types.ts
+++ b/src/modules/api/types.ts
@@ -38,6 +38,7 @@ export interface IApiComponent {
   events: EventEmitter
   fetchData: () => Promise<Result>
   fetchUpdatedData: (updatedAfter: number) => Promise<Result>
+  getDissolvedEstate: (estateId: string) => Promise<NFT | null>
 }
 
 export type OrderFragment = {
@@ -80,6 +81,15 @@ export type ParcelFragment = {
         updatedAt: string
       }
     } | null
+  }
+}
+
+export type DissolvedEstateFragment = {
+  name: string
+  estate: {
+    data: {
+      description: string
+    }
   }
 }
 

--- a/src/modules/api/utils.ts
+++ b/src/modules/api/utils.ts
@@ -9,7 +9,12 @@ import fetch from 'node-fetch'
 import { sleep } from '../map/utils'
 
 // helper to do GraphQL queries with retry logic
-export async function graphql<T>(url: string, query: string, retries = 5, retryDelay = 500): Promise<T> {
+export async function graphql<T>(
+  url: string,
+  query: string,
+  retries = 5,
+  retryDelay = 500
+): Promise<T> {
   try {
     const res = await fetch(url, {
       method: 'post',

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -19,6 +19,7 @@ export interface IMapComponent {
   getTiles: () => Promise<Record<string, Tile>>
   getParcel: (x: string | number, y: string | number) => Promise<NFT | null>
   getEstate: (id: string) => Promise<NFT | null>
+  getDissolvedEstate: (id: string) => Promise<NFT | null>
   getToken: (contractAddress: string, tokenId: string) => Promise<NFT | null>
   isReady: () => boolean
   getLastUpdatedAt: () => number
@@ -63,7 +64,7 @@ export const tileFields = [
   'estateId',
   'tokenId',
   'price',
-  'expiresAt'
+  'expiresAt',
 ]
 
 export type SpecialTile = {


### PR DESCRIPTION
This PR adds support for responding a valid `NFT` for request to the `v2/estates/:id` and `contracts/:estateContractAddress/tokens/:estateId` endpoints when the requested `estateId` corresponds to a dissolved estate.

When an Estate is not found in memory, a `getDissolvedEstate(id: string): Promise<NFT | null>` method is called to retrieve the dissolved estate. If no estate is found then a 404 is returned (the estate never existed).

I added a few things to prevent unnecessary calls to the subgraphs and prevent potential attacks on the server:

1) Every dissolved estate fetched successfully is added to the records in memory so it won't be fetched again
2) Every id that is not found in the sugraph is added to a set so the next time is requested there's no need to hit the subgraph to give a response
3) Requests for ids higher than the latest estate id are returned as not found without hitting the subgraph. There are some edge cases where an estate that does exist in the blockchain that is not yet added to memory is requested and ends up in a 404, if we want we could add a leeway to account for these cases and still limit the surface area for an attack to just a few ids.