### PR TITLE
fix: Nullable estate data and size

### DIFF
--- a/src/modules/api/component.ts
+++ b/src/modules/api/component.ts
@@ -581,17 +581,12 @@ export async function createApiComponent(components: {
     } = fragment
     if (!estate) return null
 
-    const {
-      size,
-      parcels,
-      tokenId,
-      data: { description },
-    } = estate
+    const { size, parcels, tokenId, data } = estate
     const { name } = estate.nft
     const attributes: Attribute[] = [
       {
         trait_type: 'Size',
-        value: size,
+        value: size ?? 0,
         display_type: 'number',
       },
     ]
@@ -609,7 +604,7 @@ export async function createApiComponent(components: {
     return {
       id: tokenId,
       name,
-      description: description || '',
+      description: data?.description || '',
       image: `${imageBaseUrl}/estates/${tokenId}/map.png?size=24&width=1024&height=1024`,
       external_url: `${externalBaseUrl}/contracts/${estateContractAddress}/tokens/${tokenId}`,
       attributes,

--- a/src/modules/api/types.ts
+++ b/src/modules/api/types.ts
@@ -65,10 +65,10 @@ export type ParcelFragment = {
     } | null
     estate: {
       tokenId: string
-      size: number
+      size: number | null
       data: {
         description: string | null
-      }
+      } | null
       parcels: { x: string; y: string }[]
       nft: {
         name: string


### PR DESCRIPTION
Following the [Estate entity definition](https://github.com/decentraland/marketplace/blob/master/indexer/schema.graphql#L90):
```
type Estate @entity {
  id: ID!
  tokenId: BigInt!
  owner: Account!
  parcels: [Parcel!]! @derivedFrom(field: "estate")
  size: Int
  data: Data
  rawData: String
  nft: NFT @derivedFrom(field: "estate")
}
```
Estates size and data are nullable, so they should be considered as such. This PR changes that.