### PR TITLE
fix: Filter nulled rental listings

### DIFF
--- a/src/modules/rentals/component.ts
+++ b/src/modules/rentals/component.ts
@@ -109,6 +109,7 @@ export async function createRentalsComponent(components: {
     componentLogger.info(`Finished to get the NFTs rental listings`)
     return results
       .flatMap((result) => result.data.results)
+      .filter(Boolean)
       .reduce((rentalListings, rentalListing) => {
         return {
           ...rentalListings,
@@ -139,7 +140,7 @@ export async function createRentalsComponent(components: {
         updatedRentalListings.data.total - rentalListings.length
     } while (remainingRentalListings > 0)
     componentLogger.info(`Finished to fetch the updated rental listings`)
-    return rentalListings
+    return rentalListings.filter(Boolean)
   }
 
   return {


### PR DESCRIPTION
This PR adds a filter to remove any possible rental listings that are of null value. It's unclear why there could be nulled rental listings, but, to try and pinpoint a recurring issue we're having, I'm adding this.