### PR TITLE
feat: Improve Atlas cache

### DIFF
--- a/src/controllers/handlers.ts
+++ b/src/controllers/handlers.ts
@@ -65,7 +65,6 @@ export async function miniMapHandler(context: Context) {
       status: 200,
       headers: {
         'content-type': 'image/png',
-        'cache-control': 'public,s-maxage=600,max-age=600',
       },
       body: stream,
     }
@@ -94,7 +93,6 @@ export async function estateMapHandler(context: Context) {
       status: 200,
       headers: {
         'content-type': 'image/png',
-        'cache-control': 'public,s-maxage=600,max-age=600',
       },
       body: stream,
     }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -1,4 +1,5 @@
 import { AppComponents, GlobalContext } from '../types'
+import { lastModifiedMiddleware } from '../logic/last-modified-middleware'
 import {
   estateMapPngRequestHandler,
   estateRequestHandler,
@@ -28,49 +29,119 @@ export async function setupRouter(
 ): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
 
-  const { district } = components
-  router.get('/v1/tiles', createLegacyTilesRequestHandler(components))
-  router.get('/v2/tiles', createTilesRequestHandler(components))
+  const { district, map } = components
+  const getLastModifiedTime = () => map.getLastUpdatedAt()
+  const lastModifiedMiddlewareByMapDate =
+    lastModifiedMiddleware(getLastModifiedTime)
+
+  router.get(
+    '/v1/tiles',
+    lastModifiedMiddlewareByMapDate,
+    createLegacyTilesRequestHandler(components)
+  )
+  router.get(
+    '/v2/tiles',
+    lastModifiedMiddlewareByMapDate,
+    createTilesRequestHandler(components)
+  )
   router.get('/v2/tiles/info', tilesInfoRequestHandler)
-  router.get('/v1/map.png', mapPngRequestHandler)
-  router.get('/v1/minimap.png', miniMapHandler)
-  router.get('/v1/estatemap.png', estateMapHandler)
-  router.get('/v1/parcels/:x/:y/map.png', parcelMapPngRequestHandler)
-  router.get('/v1/estates/:estateId/map.png', estateMapPngRequestHandler)
-  router.get('/v2/map.png', mapPngRequestHandler)
-  router.get('/v2/parcels/:x/:y/map.png', parcelMapPngRequestHandler)
-  router.get('/v2/estates/:estateId/map.png', estateMapPngRequestHandler)
+  router.get(
+    '/v1/map.png',
+    lastModifiedMiddlewareByMapDate,
+    mapPngRequestHandler
+  )
+  router.get(
+    '/v1/minimap.png',
+    lastModifiedMiddleware(getLastModifiedTime, {
+      maxAge: 600,
+      staleWhileRevalidate: 600,
+    }),
+    miniMapHandler
+  )
+  router.get(
+    '/v1/estatemap.png',
+    lastModifiedMiddleware(getLastModifiedTime, {
+      maxAge: 600,
+      staleWhileRevalidate: 600,
+    }),
+    estateMapHandler
+  )
+  router.get(
+    '/v1/parcels/:x/:y/map.png',
+    lastModifiedMiddlewareByMapDate,
+    parcelMapPngRequestHandler
+  )
+  router.get(
+    '/v1/estates/:estateId/map.png',
+    lastModifiedMiddlewareByMapDate,
+    estateMapPngRequestHandler
+  )
+  router.get(
+    '/v2/map.png',
+    lastModifiedMiddlewareByMapDate,
+    mapPngRequestHandler
+  )
+  router.get(
+    '/v2/parcels/:x/:y/map.png',
+    lastModifiedMiddlewareByMapDate,
+    parcelMapPngRequestHandler
+  )
+  router.get(
+    '/v2/estates/:estateId/map.png',
+    lastModifiedMiddlewareByMapDate,
+    estateMapPngRequestHandler
+  )
   router.get('/v2/ping', pingRequestHandler)
   router.get('/v2/ready', readyRequestHandler)
-  router.get('/v2/parcels/:x/:y', parcelRequestHandler)
-  router.get('/v2/estates/:id', estateRequestHandler)
-  router.get('/v2/contracts/:address/tokens/:id', tokenRequestHandler)
-  router.get('/v2/districts', async () => ({
+  router.get(
+    '/v2/parcels/:x/:y',
+    lastModifiedMiddlewareByMapDate,
+    parcelRequestHandler
+  )
+  router.get(
+    '/v2/estates/:id',
+    lastModifiedMiddlewareByMapDate,
+    estateRequestHandler
+  )
+  router.get(
+    '/v2/contracts/:address/tokens/:id',
+    lastModifiedMiddlewareByMapDate,
+    tokenRequestHandler
+  )
+  router.get('/v2/districts', lastModifiedMiddlewareByMapDate, async () => ({
     status: 200,
     body: { ok: true, data: district.getDistricts() },
   }))
-  router.get('/v2/districts/:id', async (req) => {
-    const result = district.getDistrict(req.params.id)
-    if (result) {
-      return {
-        status: 200,
-        body: { ok: true, data: result },
-      }
-    } else {
-      return {
-        status: 404,
-        body: 'Not found',
+  router.get(
+    '/v2/districts/:id',
+    lastModifiedMiddlewareByMapDate,
+    async (req) => {
+      const result = district.getDistrict(req.params.id)
+      if (result) {
+        return {
+          status: 200,
+          body: { ok: true, data: result },
+        }
+      } else {
+        return {
+          status: 404,
+          body: 'Not found',
+        }
       }
     }
-  })
+  )
 
-  router.get('/v2/addresses/:address/contributions', async (req) => ({
-    status: 200,
-    body: {
-      ok: true,
-      data: district.getContributionsByAddress(req.params.address),
-    },
-  }))
+  router.get(
+    '/v2/addresses/:address/contributions',
+    lastModifiedMiddlewareByMapDate,
+    async (req) => ({
+      status: 200,
+      body: {
+        ok: true,
+        data: district.getContributionsByAddress(req.params.address),
+      },
+    })
+  )
 
   return router
 }

--- a/src/logic/last-modified-middleware.ts
+++ b/src/logic/last-modified-middleware.ts
@@ -1,0 +1,47 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { Context } from '../types'
+
+const THREE_MINUTES = 180
+const TWO_MINUTES = 120
+
+export function lastModifiedMiddleware(
+  getLastModifiedTime: () => number,
+  options: { maxAge?: number; staleWhileRevalidate?: number } = {
+    maxAge: TWO_MINUTES,
+    staleWhileRevalidate: THREE_MINUTES,
+  }
+): IHttpServerComponent.IRequestHandler<Context<string>> {
+  const cacheControlHeader = `max-age=${options.maxAge}, stale-while-revalidate=${options.staleWhileRevalidate}, public`
+
+  return async (context, next): Promise<IHttpServerComponent.IResponse> => {
+    const lastModifiedTime = getLastModifiedTime()
+    const lastModifiedHeader = new Date(lastModifiedTime).toUTCString()
+    const ifModifiedSinceHeader =
+      context.request.headers.get('If-Modified-Since')
+
+    if (ifModifiedSinceHeader) {
+      const ifModifiedSinceTime = Date.parse(ifModifiedSinceHeader)
+      if (
+        !isNaN(ifModifiedSinceTime) &&
+        lastModifiedTime <= ifModifiedSinceTime
+      ) {
+        return {
+          status: 304,
+          headers: {
+            'Last-Modified': lastModifiedHeader,
+            'Cache-Control': cacheControlHeader,
+          },
+        }
+      }
+    }
+
+    const response = await next()
+    response.headers = {
+      ...response.headers,
+      'Last-Modified': lastModifiedHeader,
+      'Cache-Control': cacheControlHeader,
+    }
+
+    return response
+  }
+}

--- a/tests/logic/last-modified-middlware-logic.spec.ts
+++ b/tests/logic/last-modified-middlware-logic.spec.ts
@@ -1,0 +1,153 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { lastModifiedMiddleware } from '../../src/logic/last-modified-middleware'
+import { Headers, Request } from 'node-fetch'
+import { Context } from '../../src/types'
+
+let mockedResponse: IHttpServerComponent.IResponse
+let mockedRequest: IHttpServerComponent.IRequest
+let mockedContext: IHttpServerComponent.DefaultContext<Context<string>>
+let mockedGetLastModifiedTime: () => number
+let lastModifiedUTSCString: string
+let middleware: ReturnType<typeof lastModifiedMiddleware>
+
+beforeEach(() => {
+  mockedResponse = {}
+  mockedRequest = { headers: new Headers() } as Request
+  mockedContext = {
+    request: mockedRequest,
+    components: {} as any,
+    params: {},
+    url: new URL('http://localhost'),
+  }
+  mockedGetLastModifiedTime = () => Date.parse(lastModifiedUTSCString)
+  middleware = lastModifiedMiddleware(mockedGetLastModifiedTime)
+})
+
+describe('when handling a request with a If-Modified-Since header', () => {
+  describe('when the If-Modified-Since header is a valid date', () => {
+    beforeEach(() => {
+      mockedRequest.headers.set(
+        'If-Modified-Since',
+        'Tue, 20 Jan 1970 11:55:03 GMT'
+      )
+    })
+
+    describe('when the If-Modified-Since header is before the last modified time', () => {
+      beforeEach(() => {
+        lastModifiedUTSCString = 'Tue, 20 Jan 1970 15:00:03 GMT'
+      })
+
+      it("should return a 200 OK response with the next handlers's data, the Last-Modified and the Cache-Control headers", () => {
+        return expect(
+          middleware(mockedContext, () => Promise.resolve(mockedResponse))
+        ).resolves.toEqual({
+          ...mockedResponse,
+          headers: {
+            'Last-Modified': lastModifiedUTSCString,
+            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+          },
+        })
+      })
+    })
+
+    describe('when the If-Modified-Since header is the same as last modified time', () => {
+      beforeEach(() => {
+        lastModifiedUTSCString = 'Tue, 20 Jan 1970 11:55:03 GMT'
+        mockedResponse = { status: 200, body: 'ok' }
+      })
+
+      it('should return a 304 Not Modified response', () => {
+        return expect(
+          middleware(mockedContext, () => Promise.resolve(mockedResponse))
+        ).resolves.toEqual({
+          status: 304,
+          headers: {
+            'Last-Modified': lastModifiedUTSCString,
+            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+          },
+        })
+      })
+    })
+
+    describe('when the If-Modified-Since header is after the last modified time', () => {
+      beforeEach(() => {
+        lastModifiedUTSCString = 'Tue, 20 Jan 1970 11:10:03 GMT'
+        mockedResponse = { status: 200, body: 'ok' }
+      })
+
+      it('should return a 304 Not Modified response', () => {
+        return expect(
+          middleware(mockedContext, () => Promise.resolve(mockedResponse))
+        ).resolves.toEqual({
+          status: 304,
+          headers: {
+            'Last-Modified': lastModifiedUTSCString,
+            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+          },
+        })
+      })
+    })
+  })
+
+  describe('when the If-Modified-Since header is not a valid date', () => {
+    beforeEach(() => {
+      mockedRequest.headers.set('If-Modified-Since', 'Something wrong')
+      mockedResponse = { status: 200, body: 'ok' }
+      lastModifiedUTSCString = 'Sun, 25 Jan 1970 10:00:03 GMT'
+    })
+
+    it("should return a 200 OK response with the next handlers's data, the Last-Modified and the Cache-Control headers", () => {
+      return expect(
+        middleware(mockedContext, () => Promise.resolve(mockedResponse))
+      ).resolves.toEqual({
+        ...mockedResponse,
+        headers: {
+          'Last-Modified': lastModifiedUTSCString,
+          'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+        },
+      })
+    })
+  })
+})
+
+describe('when handling a request without a If-Modified-Since header', () => {
+  beforeEach(() => {
+    lastModifiedUTSCString = 'Sun, 25 Jan 1970 10:00:03 GMT'
+    mockedResponse = { status: 200, body: 'ok' }
+  })
+
+  it("should return a 200 OK response with the next handlers's data, the Last-Modified and the Cache-Control headers", () => {
+    return expect(
+      middleware(mockedContext, () => Promise.resolve(mockedResponse))
+    ).resolves.toEqual({
+      ...mockedResponse,
+      headers: {
+        'Last-Modified': lastModifiedUTSCString,
+        'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+      },
+    })
+  })
+})
+
+describe('when setting the max age and the stale while revalidate options', () => {
+  beforeEach(() => {
+    lastModifiedUTSCString = 'Sun, 25 Jan 1970 10:00:03 GMT'
+    mockedResponse = { status: 200, body: 'ok' }
+    middleware = lastModifiedMiddleware(mockedGetLastModifiedTime, {
+      maxAge: 600,
+      staleWhileRevalidate: 600,
+    })
+  })
+
+  it('should return a response with the Last-Modified and the Cache-Control headers set as in the options', () => {
+    return expect(
+      middleware(mockedContext, () => Promise.resolve(mockedResponse))
+    ).resolves.toEqual({
+      ...mockedResponse,
+      headers: {
+        'Last-Modified': lastModifiedUTSCString,
+        'Cache-Control': 'max-age=600, stale-while-revalidate=600, public',
+      },
+    })
+  })
+})


### PR DESCRIPTION
This PR creates a new middleware that:
- Will handle the `If-Modified-Since` header and return a 304 or 200 status.
- Will return the `Last-Modified` header with the date the map changed.
- Will return the Cache-Control header with a 2 minute age and a three minutes stale time to improve Cloudfare's and consumer's cache.