### PR TITLE
fix: Use seconds

### DIFF
--- a/src/adapters/time.ts
+++ b/src/adapters/time.ts
@@ -1,0 +1,7 @@
+export function fromMillisecondsToSeconds(timeInMilliseconds: number): number {
+  return Math.floor(timeInMilliseconds / 1000)
+}
+
+export function fromSecondsToMilliseconds(timeInSeconds: number): number {
+  return timeInSeconds * 1000
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -30,7 +30,7 @@ export async function setupRouter(
   const router = new Router<GlobalContext>()
 
   const { district, map } = components
-  const getLastModifiedTime = () => map.getLastUpdatedAt()
+  const getLastModifiedTime = () => map.getLastUpdatedAt() * 1000
   const lastModifiedMiddlewareByMapDate =
     lastModifiedMiddleware(getLastModifiedTime)
 

--- a/src/modules/api/types.ts
+++ b/src/modules/api/types.ts
@@ -9,10 +9,8 @@ export type Batch = {
   tiles: Tile[]
   parcels: NFT[]
   estates: NFT[]
-  /** The time in seconds the last rent was updated */
-  lastRentalUpdate: number
 }
-export type Result = Omit<Batch, 'lastRentalUpdate'> & { updatedAt: number }
+export type Result = Batch & { updatedAt: number }
 
 export type NFT = {
   id: string

--- a/src/modules/api/types.ts
+++ b/src/modules/api/types.ts
@@ -5,8 +5,14 @@ export enum ApiEvents {
   PROGRESS = 'progress',
 }
 
-export type Batch = { tiles: Tile[]; parcels: NFT[]; estates: NFT[] }
-export type Result = Batch & { updatedAt: number }
+export type Batch = {
+  tiles: Tile[]
+  parcels: NFT[]
+  estates: NFT[]
+  /** The time in seconds the last rent was updated */
+  lastRentalUpdate: number
+}
+export type Result = Omit<Batch, 'lastRentalUpdate'> & { updatedAt: number }
 
 export type NFT = {
   id: string
@@ -36,6 +42,7 @@ export interface IApiComponent {
 
 export type OrderFragment = {
   price: string
+  /** The time in milliseconds when the order expires */
   expiresAt: string
 }
 

--- a/src/modules/api/utils.ts
+++ b/src/modules/api/utils.ts
@@ -15,7 +15,7 @@ import {
 import proximities from './data/proximity.json'
 
 export function isExpired(order: OrderFragment) {
-  return parseInt(order.expiresAt) <= Date.now() / 1000
+  return parseInt(order.expiresAt) <= Math.round(Date.now() / 1000)
 }
 
 export const getProximity = (

--- a/src/modules/api/utils.ts
+++ b/src/modules/api/utils.ts
@@ -15,7 +15,7 @@ import {
 import proximities from './data/proximity.json'
 
 export function isExpired(order: OrderFragment) {
-  return parseInt(order.expiresAt) <= Date.now()
+  return parseInt(order.expiresAt) <= Date.now() / 1000
 }
 
 export const getProximity = (

--- a/tests/modules/api.spec.ts
+++ b/tests/modules/api.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@well-known-components/interfaces'
 import { ISubgraphComponent } from '@well-known-components/thegraph-component'
 import { convertRentalListingToTileRentalListing } from '../../src/adapters/rentals'
+import { fromMillisecondsToSeconds } from '../../src/adapters/time'
 import { Metrics } from '../../src/metrics'
 import { createApiComponent } from '../../src/modules/api/component'
 import {
@@ -51,7 +52,7 @@ beforeEach(async () => {
     searchParcelY: '1',
     searchParcelEstateId: null,
     tokenId: '0',
-    updatedAt: date.toString(),
+    updatedAt: fromMillisecondsToSeconds(date).toString(),
     activeOrder: {
       price: '1000000000000000000',
       expiresAt: (date + 100000000).toString(),
@@ -71,7 +72,7 @@ beforeEach(async () => {
     searchParcelX: '1',
     searchParcelY: '1',
     tokenId: '1',
-    updatedAt: date.toString(),
+    updatedAt: fromMillisecondsToSeconds(date).toString(),
     activeOrder: {
       price: '2000000000000000000',
       expiresAt: (date + 100000000).toString(),
@@ -101,7 +102,7 @@ beforeEach(async () => {
             price: '2000000000000000000',
             expiresAt: (date + 100000000).toString(),
           },
-          updatedAt: date.toString(),
+          updatedAt: fromMillisecondsToSeconds(date).toString(),
         },
       },
     },
@@ -776,7 +777,7 @@ describe('when fetching update data', () => {
 
   beforeEach(() => {
     fstEstate = {
-      updatedAt: date.toString(),
+      updatedAt: fromMillisecondsToSeconds(date).toString(),
       estate: {
         parcels: [
           { nft: defaultFstParcelEstate },


### PR DESCRIPTION
This PR changes the code to use milliseconds when returning the `If-Modified-Since` header.
It also makes sure that the `getLastUpdatedAt` always returns a number representing the unix timestamp in seconds.