### PR TITLE
feat: Use node 18 alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
 ARG RUN
 
-FROM node:lts as builderenv
+FROM node:18-alpine as builderenv
 
 WORKDIR /app
 
 # some packages require a build step
-RUN apt-get update
-RUN apt-get -y -qq install python-setuptools python-dev build-essential
-
-# We use Tini to handle signals and PID1 (https://github.com/krallin/tini, read why here https://github.com/krallin/tini/issues/8)
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+RUN apk update
+RUN apk add --no-cache py3-setuptools python3-dev build-base
 
 # install dependencies
 COPY package.json /app/package.json
@@ -21,30 +16,31 @@ RUN npm ci
 # build the app
 COPY . /app
 RUN npm run build
-
-# Test the app
 RUN npm run test
 
 # remove devDependencies, keep only used dependencies
 RUN npm ci --only=production
 
+
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:lts
+FROM node:18-alpine
+
+RUN apk update
+RUN apk add --no-cache tini
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production
 
 ARG COMMIT_HASH=local
-ENV COMMIT_HASH=${COMMIT_HASH:-local}
+ENV COMMIT_HASH=${COMMIT_HASH:-local}   
 
 WORKDIR /app
 COPY --from=builderenv /app /app
-COPY --from=builderenv /tini /tini
 # Please _DO NOT_ use a custom ENTRYPOINT because it may prevent signals
 # (i.e. SIGTERM) to reach the service
 # Read more here: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/
 #            and: https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 # Run the program under Tini
 CMD [ "/usr/local/bin/node", "--trace-warnings", "--abort-on-uncaught-exception", "--unhandled-rejections=strict", "dist/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache tini \
 ENV NODE_ENV production
 
 ARG COMMIT_HASH=local
-ENV COMMIT_HASH=${COMMIT_HASH:-local}   
+ENV COMMIT_HASH=${COMMIT_HASH:-local}
 
 WORKDIR /app
 COPY --from=builderenv /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,14 @@ WORKDIR /app
 
 # some packages require a build step
 RUN apk update
-RUN apk add --no-cache py3-setuptools python3-dev build-base
+RUN apk add --no-cache py3-setuptools \
+  python3-dev \
+  build-base \ 
+  g++ \
+  cairo-dev \
+  jpeg-dev \
+  pango-dev \
+  giflib-dev
 
 # install dependencies
 COPY package.json /app/package.json
@@ -27,7 +34,11 @@ RUN npm ci --only=production
 FROM node:18-alpine
 
 RUN apk update
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini \
+  cairo \
+  jpeg \
+  pango \
+  giflib
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production


### PR DESCRIPTION
This PR changes the Docker image to use node 18 in its alpine version, reducing vulnerabilities and the image size.