### PR TITLE
fix: Query signatures server using milliseconds instead of seconds

### DIFF
--- a/src/modules/api/component.ts
+++ b/src/modules/api/component.ts
@@ -18,7 +18,10 @@ import {
   TileRentalListing,
 } from '../../adapters/rentals'
 import { isRentalListingOpen } from '../../logic/rental'
-import { fromMillisecondsToSeconds } from '../../adapters/time'
+import {
+  fromMillisecondsToSeconds,
+  fromSecondsToMilliseconds,
+} from '../../adapters/time'
 import { Metrics } from '../../metrics'
 import { Tile, TileType } from '../map/types'
 import { coordsToId, specialTiles } from '../map/utils'
@@ -274,8 +277,9 @@ export async function createApiComponent(components: {
         }
       }`
       )
-      const updatedRentalListings =
-        rentals.getUpdatedRentalListings(updatedAfter)
+      const updatedRentalListings = rentals.getUpdatedRentalListings(
+        fromSecondsToMilliseconds(updatedAfter)
+      )
 
       let parcels: ParcelFragment[] = []
       let estates: EstateFragment[] = []

--- a/src/modules/rentals/component.ts
+++ b/src/modules/rentals/component.ts
@@ -41,7 +41,6 @@ export async function createRentalsComponent(components: {
         },
       }
     )
-
     if (!response.ok) {
       let parsedErrorResult: SignaturesServerErrorResponse<any> | undefined
       try {


### PR DESCRIPTION
As the JSDoc says, the server admits a date in milliseconds and we're querying the server using seconds.
```
  /** Gets the updated rental listings that were updated after the given date.
   * @param updatedAfter A UTC timestamp in milliseconds of the rental listings update time.
   * @throws An error if the request fails.
   */
```