### PR TITLE
fix: Use no-cache when responding to the last updated time

### DIFF
--- a/src/controllers/handlers.ts
+++ b/src/controllers/handlers.ts
@@ -381,11 +381,20 @@ export async function tilesInfoRequestHandler(context: {
 }) {
   const { map } = context.components
   if (!map.isReady()) {
-    return { status: 503, body: 'Not ready' }
+    return {
+      status: 503,
+      body: 'Not ready',
+      headers: {
+        'cache-control': 'no-cache',
+      },
+    }
   }
 
   const lastUpdatedAt = map.getLastUpdatedAt()
   return {
+    headers: {
+      'cache-control': 'no-cache',
+    },
     status: 200,
     body: { lastUpdatedAt },
   }

--- a/src/logic/last-modified-middleware.ts
+++ b/src/logic/last-modified-middleware.ts
@@ -11,7 +11,7 @@ export function lastModifiedMiddleware(
     staleWhileRevalidate: THREE_MINUTES,
   }
 ): IHttpServerComponent.IRequestHandler<Context<string>> {
-  const cacheControlHeader = `max-age=${options.maxAge}, stale-while-revalidate=${options.staleWhileRevalidate}, public`
+  const cacheControlHeader = `max-age=${options.maxAge}, s-maxage=${options.maxAge}, stale-while-revalidate=${options.staleWhileRevalidate}, public`
 
   return async (context, next): Promise<IHttpServerComponent.IResponse> => {
     const lastModifiedTime = getLastModifiedTime()

--- a/tests/logic/last-modified-middlware-logic.spec.ts
+++ b/tests/logic/last-modified-middlware-logic.spec.ts
@@ -44,7 +44,8 @@ describe('when handling a request with a If-Modified-Since header', () => {
           ...mockedResponse,
           headers: {
             'Last-Modified': lastModifiedUTSCString,
-            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+            'Cache-Control':
+              'max-age=120, s-maxage=120, stale-while-revalidate=180, public',
           },
         })
       })
@@ -63,7 +64,8 @@ describe('when handling a request with a If-Modified-Since header', () => {
           status: 304,
           headers: {
             'Last-Modified': lastModifiedUTSCString,
-            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+            'Cache-Control':
+              'max-age=120, s-maxage=120, stale-while-revalidate=180, public',
           },
         })
       })
@@ -82,7 +84,8 @@ describe('when handling a request with a If-Modified-Since header', () => {
           status: 304,
           headers: {
             'Last-Modified': lastModifiedUTSCString,
-            'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+            'Cache-Control':
+              'max-age=120, s-maxage=120, stale-while-revalidate=180, public',
           },
         })
       })
@@ -103,7 +106,8 @@ describe('when handling a request with a If-Modified-Since header', () => {
         ...mockedResponse,
         headers: {
           'Last-Modified': lastModifiedUTSCString,
-          'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+          'Cache-Control':
+            'max-age=120, s-maxage=120, stale-while-revalidate=180, public',
         },
       })
     })
@@ -123,7 +127,8 @@ describe('when handling a request without a If-Modified-Since header', () => {
       ...mockedResponse,
       headers: {
         'Last-Modified': lastModifiedUTSCString,
-        'Cache-Control': 'max-age=120, stale-while-revalidate=180, public',
+        'Cache-Control':
+          'max-age=120, s-maxage=120, stale-while-revalidate=180, public',
       },
     })
   })
@@ -146,7 +151,8 @@ describe('when setting the max age and the stale while revalidate options', () =
       ...mockedResponse,
       headers: {
         'Last-Modified': lastModifiedUTSCString,
-        'Cache-Control': 'max-age=600, stale-while-revalidate=600, public',
+        'Cache-Control':
+          'max-age=600, s-maxage=600, stale-while-revalidate=600, public',
       },
     })
   })


### PR DESCRIPTION
This PR adds the no-cache directive to prevent the endpoint that returns the time in which the atlas was lastly updated.