### PR TITLE
fix: consider updated at from the graph

### DIFF
--- a/src/modules/api/component.ts
+++ b/src/modules/api/component.ts
@@ -375,7 +375,10 @@ export async function createApiComponent(components: {
             const currentTile = tilesByTokenId[tokenId]
             return {
               ...currentTile,
-              updatedAt: Math.max(currentTile.updatedAt, rentalListing.updatedAt),
+              updatedAt: Math.max(
+                currentTile.updatedAt,
+                rentalListing.updatedAt
+              ),
               rentalListing: isRentalListingOpen(rentalListing)
                 ? convertRentalListingToTileRentalListing(rentalListing)
                 : undefined,
@@ -454,9 +457,12 @@ export async function createApiComponent(components: {
       }
 
       // tiles already have the updateAt value in ms
-      const tilesLastUpdatedAt = batch.tiles.reduce<number>(
-        (updatedAt, tile) => Math.max(updatedAt, tile.updatedAt),
-        0
+      const tilesLastUpdatedAt = fromSecondsToMilliseconds(
+        parcels.reduce<number>(
+          (updatedAt, parcel) =>
+            Math.max(updatedAt, parseInt(parcel.updatedAt, 10)),
+          0
+        )
       )
 
       // using estes from graph so we need to convert the updatedAt in ms as they come in seconds

--- a/tests/modules/api.spec.ts
+++ b/tests/modules/api.spec.ts
@@ -1296,7 +1296,7 @@ describe('when fetching update data', () => {
         ],
         parcels: [updatedDefaultParcelNFT],
         estates: [],
-        updatedAt: date,
+        updatedAt: defaultParcelTile.updatedAt,
       })
     })
   })
@@ -1387,7 +1387,7 @@ describe('when fetching update data', () => {
           defaultSndParcelEstateNFT,
         ],
         estates: [fstEstateNFT],
-        updatedAt: fstEstateRentalListing.updatedAt,
+        updatedAt: Math.min(fstEstateRentalListing.updatedAt, fromSecondsToMilliseconds(parseInt(fstEstate.updatedAt, 10))),
       })
     })
   })


### PR DESCRIPTION
When considering the latest updated at from parcels and estates only consider the values received from the graph call and not the one of the merge tiles