### PR TITLE
feat: try to use the S3 tiles version if  available instead of returning 503

### DIFF
--- a/tests/controllers/handlers.spec.ts
+++ b/tests/controllers/handlers.spec.ts
@@ -1,0 +1,301 @@
+import { IFeaturesComponent } from '@well-known-components/features-component'
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { EventEmitter } from 'events'
+import { IMapComponent } from '../../src/modules/map/types'
+import {
+  createTilesRequestHandler,
+  createLegacyTilesRequestHandler,
+} from '../../src/controllers/handlers'
+
+type HandlerResponse = {
+  status: number
+  headers?: Record<string, string>
+  body?: string | Record<string, unknown>
+}
+
+describe('Tiles Request Handlers', () => {
+  let mapComponentMock: IMapComponent
+  let featuresComponentMock: IFeaturesComponent
+  let loggerComponentMock: ILoggerComponent
+  let loggerWarnMock: jest.Mock
+  const s3Url = 'https://s3.example.com/tiles'
+
+  beforeEach(() => {
+    loggerWarnMock = jest.fn()
+    loggerComponentMock = {
+      getLogger: () => ({
+        warn: loggerWarnMock,
+        info: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        log: jest.fn(),
+      }),
+    }
+
+    const events = new EventEmitter()
+    mapComponentMock = {
+      isReady: jest.fn(),
+      getTiles: jest.fn().mockResolvedValue({}),
+      getLastUploadedTilesUrl: jest.fn().mockReturnValue({
+        v1: `${s3Url}/v1`,
+        v2: `${s3Url}/v2`,
+      }),
+      getLastUpdatedAt: jest.fn().mockReturnValue(Date.now()),
+      events,
+      getParcel: jest.fn(),
+      getEstate: jest.fn(),
+      getDissolvedEstate: jest.fn(),
+      getToken: jest.fn(),
+    }
+
+    featuresComponentMock = {
+      getIsFeatureEnabled: jest.fn(),
+      getEnvFeature: jest.fn(),
+      getFeatureVariant: jest.fn(),
+    }
+  })
+
+  describe('createTilesRequestHandler', () => {
+    describe('when map is not ready', () => {
+      beforeEach(() => {
+        mapComponentMock.isReady = jest.fn().mockReturnValue(false)
+      })
+
+      describe('and S3 redirect feature is OFF', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(false)
+        })
+
+        it('should return 503 status', async () => {
+          const handler = createTilesRequestHandler({ 
+            map: mapComponentMock, 
+            features: featuresComponentMock,
+            logs: loggerComponentMock
+          })
+          const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+          expect(result.status).toBe(503)
+          expect(result.body).toBe('Not ready')
+        })
+      })
+
+      describe('and S3 redirect feature is ON', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(true)
+        })
+
+        describe('and S3 URL is available', () => {
+          it('should return 301 redirect to S3', async () => {
+            const handler = createTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(301)
+            expect(result.headers?.location).toBe(`${s3Url}/v2`)
+          })
+        })
+
+        describe('and S3 URL is not available', () => {
+          beforeEach(() => {
+            mapComponentMock.getLastUploadedTilesUrl = jest.fn().mockReturnValue({})
+          })
+
+          it('should return 503 status since map is not ready and no S3 fallback', async () => {
+            const handler = createTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(503)
+            expect(result.body).toBe('Not ready')
+            expect(loggerWarnMock).toHaveBeenCalledWith('No S3 file available')
+          })
+        })
+      })
+    })
+
+    describe('when map is ready', () => {
+      beforeEach(() => {
+        mapComponentMock.isReady = jest.fn().mockReturnValue(true)
+      })
+
+      describe('and S3 redirect feature is ON', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(true)
+        })
+
+        describe('and S3 URL is available', () => {
+          it('should return 301 redirect to S3', async () => {
+            const handler = createTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(301)
+            expect(result.headers?.location).toBe(`${s3Url}/v2`)
+          })
+        })
+
+        describe('and S3 URL is not available', () => {
+          beforeEach(() => {
+            mapComponentMock.getLastUploadedTilesUrl = jest.fn().mockReturnValue({})
+          })
+
+          it('should serve tiles from map and log warning', async () => {
+            const handler = createTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(200)
+            expect(loggerWarnMock).toHaveBeenCalledWith('No S3 file available')
+            expect(result.headers?.['content-type']).toBe('application/json')
+          })
+        })
+      })
+
+      describe('and S3 redirect feature is OFF', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(false)
+        })
+
+        it('should serve tiles from map', async () => {
+          const handler = createTilesRequestHandler({ 
+            map: mapComponentMock, 
+            features: featuresComponentMock,
+            logs: loggerComponentMock
+          })
+          const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+          expect(result.status).toBe(200)
+          expect(result.headers?.['content-type']).toBe('application/json')
+        })
+      })
+    })
+  })
+
+  describe('createLegacyTilesRequestHandler', () => {
+    describe('when map is not ready', () => {
+      beforeEach(() => {
+        mapComponentMock.isReady = jest.fn().mockReturnValue(false)
+      })
+
+      describe('and S3 redirect feature is OFF', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(false)
+        })
+
+        it('should return 503 status', async () => {
+          const handler = createLegacyTilesRequestHandler({ 
+            map: mapComponentMock, 
+            features: featuresComponentMock,
+            logs: loggerComponentMock
+          })
+          const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+          expect(result.status).toBe(503)
+          expect(result.body).toBe('Not ready')
+        })
+      })
+
+      describe('and S3 redirect feature is ON', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(true)
+        })
+
+        describe('and S3 URL is available', () => {
+          it('should return 301 redirect to S3', async () => {
+            const handler = createLegacyTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(301)
+            expect(result.headers?.location).toBe(`${s3Url}/v1`)
+          })
+        })
+
+        describe('and S3 URL is not available', () => {
+          beforeEach(() => {
+            mapComponentMock.getLastUploadedTilesUrl = jest.fn().mockReturnValue({})
+          })
+
+          it('should return 503 status since map is not ready and no S3 fallback', async () => {
+            const handler = createLegacyTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(503)
+            expect(result.body).toBe('Not ready')
+            expect(loggerWarnMock).toHaveBeenCalledWith('No S3 file available')
+          })
+        })
+      })
+    })
+
+    describe('when map is ready', () => {
+      beforeEach(() => {
+        mapComponentMock.isReady = jest.fn().mockReturnValue(true)
+      })
+
+      describe('and S3 redirect feature is ON', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(true)
+        })
+
+        describe('and S3 URL is available', () => {
+          it('should return 301 redirect to S3', async () => {
+            const handler = createLegacyTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(301)
+            expect(result.headers?.location).toBe(`${s3Url}/v1`)
+          })
+        })
+
+        describe('and S3 URL is not available', () => {
+          beforeEach(() => {
+            mapComponentMock.getLastUploadedTilesUrl = jest.fn().mockReturnValue({})
+          })
+
+          it('should serve tiles from map and log warning', async () => {
+            const handler = createLegacyTilesRequestHandler({ 
+              map: mapComponentMock, 
+              features: featuresComponentMock,
+              logs: loggerComponentMock
+            })
+            const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+            expect(result.status).toBe(200)
+            expect(loggerWarnMock).toHaveBeenCalledWith('No S3 file available')
+            expect(result.headers?.['content-type']).toBe('application/json')
+          })
+        })
+      })
+
+      describe('and S3 redirect feature is OFF', () => {
+        beforeEach(() => {
+          featuresComponentMock.getIsFeatureEnabled = jest.fn().mockResolvedValue(false)
+        })
+
+        it('should serve tiles from map', async () => {
+          const handler = createLegacyTilesRequestHandler({ 
+            map: mapComponentMock, 
+            features: featuresComponentMock,
+            logs: loggerComponentMock
+          })
+          const result = await handler({ url: new URL('http://localhost') }) as HandlerResponse
+          expect(result.status).toBe(200)
+          expect(result.headers?.['content-type']).toBe('application/json')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Atlas Server - S3 Redirect Enhancement

## Context
Currently, when the map is not ready, the server returns a 503 status code. However, we have a feature flag that allows redirecting to S3 where we store cached versions of the tiles. This PR enhances the logic to use S3 redirects when available, even when the map is not ready.

## Changes
- Modified the tiles handlers (`createTilesRequestHandler` and `createLegacyTilesRequestHandler`) to:
  1. Check for S3 redirect feature flag first
  2. If enabled and S3 URL is available, redirect to S3 (regardless of map ready state)
  3. If enabled but no S3 URL available, fall back to map state check
  4. If disabled, maintain original behavior

### Logic Flow
When map is not ready:
- S3 feature OFF → 503 "Not ready"
- S3 feature ON + S3 URL available → 301 redirect to S3
- S3 feature ON + S3 URL not available → 503 "Not ready" + warning log

When map is ready:
- S3 feature OFF → serve from map
- S3 feature ON + S3 URL available → 301 redirect to S3
- S3 feature ON + S3 URL not available → serve from map + warning log

## Testing
Added comprehensive test suite covering all possible combinations of:
- Map ready state (ready/not ready)
- S3 redirect feature flag (ON/OFF)
- S3 URL availability (available/not available)

## Benefits
- Improved availability: Can serve tiles even when map is not ready if we have a cached version in S3
- Better resilience: Clear fallback behavior when S3 is not available
- Maintainable code: Common logic extracted into shared functions
- Full test coverage: All edge cases are tested
