### PR TITLE
fix: show estate trades as well in the tiles

### DIFF
--- a/src/modules/map/component.ts
+++ b/src/modules/map/component.ts
@@ -157,8 +157,10 @@ export async function createMapComponent(
             tile.tokenId &&
             trade.contract_address_sent &&
             trade.sent_token_id &&
-            tile.nftId.includes(trade.contract_address_sent) &&
-            tile.tokenId === trade.sent_token_id
+            ((!tile.estateId &&
+              tile.nftId.includes(trade.contract_address_sent) &&
+              tile.tokenId === trade.sent_token_id) ||
+              (tile.estateId && tile.estateId === trade.sent_token_id))
 
           return matches
         })


### PR DESCRIPTION
Estate trades were missing since we're trying to match the nft contract address from the tile (parcel) with the trade.contract_address_sent (from the estate) so they were never matching